### PR TITLE
- [FP] Update HTTPFileProvider, WebDAVFileProvider some classes, stru…

### DIFF
--- a/Sources/AEXML/Element.swift
+++ b/Sources/AEXML/Element.swift
@@ -30,7 +30,7 @@ import Foundation
     You can access its structure by using subscript like this: `element["foo"]["bar"]` which would
     return `<bar></bar>` element from `<element><foo><bar></bar></foo></element>` XML as an `AEXMLElement` object.
 */
-internal class AEXMLElement {
+public class AEXMLElement {
     
     // MARK: - Properties
     

--- a/Sources/AEXML/Error.swift
+++ b/Sources/AEXML/Error.swift
@@ -25,7 +25,7 @@
 import Foundation
 
 /// A type representing error value that can be thrown or inside `error` property of `AEXMLElement`.
-internal enum AEXMLError: Error {
+public enum AEXMLError: Error {
     /// This will be inside `error` property of `AEXMLElement` when subscript is used for not-existing element.
     case elementNotFound
     

--- a/Sources/DropboxFileProvider.swift
+++ b/Sources/DropboxFileProvider.swift
@@ -190,7 +190,7 @@ open class DropboxFileProvider: HTTPFileProvider, FileProviderSharing {
         }, completionHandler: completionHandler)
     }
     
-    override func request(for operation: FileOperationType, overwrite: Bool = false, attributes: [URLResourceKey : Any] = [:]) -> URLRequest {
+    override open func request(for operation: FileOperationType, overwrite: Bool = false, attributes: [URLResourceKey : Any] = [:]) -> URLRequest {
         
         func uploadRequest(to path: String) -> URLRequest {
             var requestDictionary = [String: Any]()
@@ -264,7 +264,7 @@ open class DropboxFileProvider: HTTPFileProvider, FileProviderSharing {
         return request
     }
     
-    override func serverError(with code: FileProviderHTTPErrorCode, path: String?, data: Data?) -> FileProviderHTTPError {
+    override open func serverError(with code: FileProviderHTTPErrorCode, path: String?, data: Data?) -> FileProviderHTTPError {
         let errorDesc: String?
         if let response = data?.deserializeJSON() {
             errorDesc = (response["user_message"] as? String) ?? ((response["error"] as? [String: Any])?["tag"] as? String)

--- a/Sources/Extensions/FoundationExtensions.swift
+++ b/Sources/Extensions/FoundationExtensions.swift
@@ -251,7 +251,7 @@ public struct ContentMIMEType: RawRepresentable, Hashable, Equatable {
     static public let googleVideo = ContentMIMEType(rawValue: "application/vnd.google-apps.video")
 }
 
-internal extension URLRequest {
+public extension URLRequest {
     mutating func setValue(authentication credential: URLCredential?, with type: AuthenticationType) {
         func base64(_ str: String) -> String {
             let plainData = str.data(using: .utf8)
@@ -392,6 +392,12 @@ internal extension URLRequest {
         jsonString = jsonString.asciiEscaped().replacingOccurrences(of: "\\/", with: "/")
         
         self.setValue(jsonString, forHTTPHeaderField: "Dropbox-API-Arg")
+    }
+    
+    mutating func setValues(forHTTPHeaderFields fields: [String : String]) {
+        for (key, value) in fields {
+            self.setValue(value, forHTTPHeaderField: key)
+        }
     }
 }
 

--- a/Sources/FileObject.swift
+++ b/Sources/FileObject.swift
@@ -185,7 +185,7 @@ extension FileObject {
 }
 
 extension FileObject {
-    internal func mapPredicate() -> [String: Any] {
+    public func mapPredicate() -> [String: Any] {
         let mapDict: [URLResourceKey: String] = [.fileURLKey: "url", .nameKey: "name", .pathKey: "path",
                                                  .fileSizeKey: "fileSize", .creationDateKey: "creationDate",
                                                  .contentModificationDateKey: "modifiedDate", .isHiddenKey: "isHidden",

--- a/Sources/OneDriveFileProvider.swift
+++ b/Sources/OneDriveFileProvider.swift
@@ -456,7 +456,7 @@ open class OneDriveFileProvider: HTTPFileProvider, FileProviderSharing {
         return upload_multipart_data(path, data: data ?? Data(), operation: operation, overwrite: overwrite, completionHandler: completionHandler)
     }
     
-    override func request(for operation: FileOperationType, overwrite: Bool = false, attributes: [URLResourceKey : Any] = [:]) -> URLRequest {
+    override open func request(for operation: FileOperationType, overwrite: Bool = false, attributes: [URLResourceKey : Any] = [:]) -> URLRequest {
         
         func correctPath(_ path: String) -> String {
             if path.hasPrefix("id:") {
@@ -548,7 +548,7 @@ open class OneDriveFileProvider: HTTPFileProvider, FileProviderSharing {
         return request
     }
     
-    override func serverError(with code: FileProviderHTTPErrorCode, path: String?, data: Data?) -> FileProviderHTTPError {
+    override open func serverError(with code: FileProviderHTTPErrorCode, path: String?, data: Data?) -> FileProviderHTTPError {
         let errorDesc: String?
         if let response = data?.deserializeJSON() {
             errorDesc = (response["error"] as? [String: Any])?["message"] as? String


### PR DESCRIPTION
…cts, functions, categories from internal to public by using in outside of package.

- [FP] Update WebDAVFileProvider some classes, structs, functions, categories from internal to public by using in outside of package.
- [FP] Update FileProvider some classes, structs, functions, categories from internal to public by using in outside of package.
- [FP] Update FileProvider WebDavFileObject size info in init by DavResponse.
- [FP] Update FileProvider WebDavFileObject info in init by DavResponse (get more information about file object in Trash). Support DavSharedResponse and WebDavSharedObject to parse share information of shared objects.
- [FP] Update FileProvider WebDavFileProvider by supporting timeoutInterval to URLRequest.
- [FP] Update FileProvider WebDavSharedObject the shareURL to optional instead of non-optional property.
- [FP] Update FileProvider WebDavSharedObject the isShared checking.
- [FP] Update FileProvider WebDAVFileProvider add shareWith to WebDavSharedObject. Support DavRecentResponse and WebDavRecentObject to parse recent information of recent objects.
- [FP] Update FileProvider add fileID to WebDavFileObject.
- [FP] Update FileProvider add headerFields to WebDavFileObject. Add function setValues(forHTTPHeaderFields:) to FoundationExtensions.
- [FP] Update FileProvider add invitedShares, invitedPeople, publicShare to WebDavFileObject.
- [FP] Update FileProvider add shareWithDisplayName to WebDavSharedObject. Remove invitedPeople from WebDavFileObject.
- [FP] Update FileProvider add invalidateSession, and configSession to HTTPFileProvider.
- [FP] Update FileProvider update headerFields in WebDavFileObject.